### PR TITLE
Add missing metadata file

### DIFF
--- a/LICENSE_UNITY.md.meta
+++ b/LICENSE_UNITY.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 39543846009c6f54caf645e58ebc8e16
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Without the missing metadata file, Unity 2021.1 gets very unhappy, since it is not allowed to create metadatafiles for included packages: 
`Asset Packages/com.arm.mobile-studio/LICENSE_UNITY.md has no meta file, but it's in an immutable folder. The asset will be ignored.`
![grafik](https://user-images.githubusercontent.com/4518980/120439280-dcea5e80-c371-11eb-8d90-9e4259771ab7.png)

This fix simply adds the missing metadata file