### PR TITLE
Complete set of CAM bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,16 +34,17 @@ This package is built using the Unity bee compiler.
 
 1) Set the environment variable `ANDROID_NDK_ROOT`
    to a local Android NDK install. Android NDK can usually be found in:
-   `\Editor\Data\PlaybackEngines\AndroidPlayer\NDK`
+   `\Editor\Data\PlaybackEngines\AndroidPlayer\NDK`.
 2) Locate the bee compiler in your Unity install. It is usually found in:
-   `\Editor\Data\il2cpp\build\BeeSettings\offline\bee.exe`
+   `\Editor\Data\il2cpp\build\BeeSettings\offline\bee.exe`.
 3) To trigger a build, run `bee.exe` in the `Native~` directory.
 
 Compatibility
 -------------
 
 This package uses application-generated Streamline annotations to add more
-context to captured data. It allocates annotation handles in the ID range 16384-32767; other users of Streamline in the same process should avoid using
+context to captured data. It allocates annotation handles in the ID range
+16384-32767; other users of Streamline in the same process should avoid using
 this range to avoid collisions.
 
 Installing and using

--- a/Runtime/MobileStudio.cs
+++ b/Runtime/MobileStudio.cs
@@ -377,6 +377,14 @@ namespace MobileStudio
              */
             public interface CAMTrack
             {
+
+                /*
+                * Creates a track with the specified name and parent. This can then be used
+                * to register Jobs. Each Track appears as a named row in the
+                * parent CAM.
+                */
+                public CAMTrack createTrack(string _name);
+
                 /*
                  * Creates a CAMJob object, which will mark itself as starting
                  * immediately. Mark completion with a call to stop() on the
@@ -460,22 +468,6 @@ namespace MobileStudio
             }
 
             /*
-             * Creates a track with the specified name and parent. This can then be used
-             * to register Jobs. Each Track appears as a named row in the
-             * parent CAM.
-             */
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public CAMTrack createTrack(CAMTrack parent, string _name)
-            {
-                CAMTrack newTrack;
-                lock(_locker)
-                {
-                    newTrack = new CAMTrackImp(this, parent, _name, ++trackCount);
-                }
-                return newTrack;
-            }
-
-            /*
              * Private implementation of the CAMTrack.
              */
             private class CAMTrackImp : CAMTrack
@@ -517,6 +509,24 @@ namespace MobileStudio
                         }
                     #endif
                 }
+
+
+                /*
+                * Creates a track with the specified name and parent. This can then be used
+                * to register Jobs. Each Track appears as a named row in the
+                * parent CAM.
+                */
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public CAMTrack createTrack(string _name)
+                {
+                    CAMTrack newTrack;
+                    lock(_locker)
+                    {
+                        newTrack = new CAMTrackImp(this.view, this, _name, ++trackCount);
+                    }
+                    return newTrack;
+                }
+
 
                 /*
                  * Creates a CAMJob object, which will mark itself as starting

--- a/Runtime/MobileStudio.cs
+++ b/Runtime/MobileStudio.cs
@@ -141,6 +141,7 @@ namespace MobileStudio
          * Returns the active state if annotations are supported (we are running on Android
          * and successfully initialized the library), inactive otherwise
          */
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static AnnotationState getAnnotationState()
         {
             #if UNITY_ANDROID && !UNITY_EDITOR

--- a/Runtime/UnityStatsProxy.cs
+++ b/Runtime/UnityStatsProxy.cs
@@ -65,13 +65,6 @@ namespace MobileStudio
         }
         List<CounterObjectPair> counters;
 
-
-        // TODO: Remove this it's just for testing
-        Annotations.CAM cam;
-        Annotations.CAMTrack track1;
-        Annotations.CAMTrack track2;
-
-
         struct CounterMapping
         {
             public CounterMapping(string mobileStudioTitle, string mobileStudioCounterName, string mobileStudioCounterUnit, string unityCounterName)
@@ -206,23 +199,6 @@ namespace MobileStudio
                 var mobileStudioCounter = new Annotations.Counter(mobileStudioDefaultCounters[i].mobileStudioTitle, mobileStudioDefaultCounters[i].mobileStudioCounterName, Annotations.CounterType.Absolute, mobileStudioDefaultCounters[i].mobileStudioCounterUnit);
                 counters.Add(new CounterObjectPair(mobileStudioCounter, recorder, mobileStudioDefaultCounters[i].mobileStudioCounterUnit == unitBytes));
             }
-
-            // Testing ...
-            cam = new Annotations.CAM("Unity Binding CAM");
-            track1 = cam.createTrack("UBC Track 1");
-            track2 = track1.createTrack("UBC Track 2");
-
-            var job1 = track1.makeJob("T1 J1", Color.green);
-            Thread.Sleep(5);
-            job1.stop();
-            Thread.Sleep(5);
-
-            var job2 = track2.makeJob("T2 J1", Color.blue);
-            Thread.Sleep(5);
-            job1.stop();
-            Thread.Sleep(5);
-
-            job2.set_dependency(job1);
         }
 
         void DisposeCounters()

--- a/Runtime/UnityStatsProxy.cs
+++ b/Runtime/UnityStatsProxy.cs
@@ -65,6 +65,13 @@ namespace MobileStudio
         }
         List<CounterObjectPair> counters;
 
+
+        // TODO: Remove this it's just for testing
+        Annotations.CAM cam;
+        Annotations.CAMTrack track1;
+        Annotations.CAMTrack track2;
+
+
         struct CounterMapping
         {
             public CounterMapping(string mobileStudioTitle, string mobileStudioCounterName, string mobileStudioCounterUnit, string unityCounterName)
@@ -199,6 +206,23 @@ namespace MobileStudio
                 var mobileStudioCounter = new Annotations.Counter(mobileStudioDefaultCounters[i].mobileStudioTitle, mobileStudioDefaultCounters[i].mobileStudioCounterName, Annotations.CounterType.Absolute, mobileStudioDefaultCounters[i].mobileStudioCounterUnit);
                 counters.Add(new CounterObjectPair(mobileStudioCounter, recorder, mobileStudioDefaultCounters[i].mobileStudioCounterUnit == unitBytes));
             }
+
+            // Testing ...
+            cam = new Annotations.CAM("Unity Binding CAM");
+            track1 = cam.createTrack("UBC Track 1");
+            track2 = track1.createTrack("UBC Track 2");
+
+            var job1 = track1.makeJob("T1 J1", Color.green);
+            Thread.Sleep(5);
+            job1.stop();
+            Thread.Sleep(5);
+
+            var job2 = track2.makeJob("T2 J1", Color.blue);
+            Thread.Sleep(5);
+            job1.stop();
+            Thread.Sleep(5);
+
+            job2.set_dependency(job1);
         }
 
         void DisposeCounters()


### PR DESCRIPTION
This PR adds additional CAM annotation bindings, making it a closer match to the Streamline native API.

* CAMTracks can be nested.
* CAMJobs can express dependencies.

Known issue: Streamline is currently ignoring CAM Job colors (confirmed Streamline bug).